### PR TITLE
<fix> : 디스코드 메세지 변환 양식 변경

### DIFF
--- a/src/main/kotlin/taeyun/malanalter/alertitem/AlertService.kt
+++ b/src/main/kotlin/taeyun/malanalter/alertitem/AlertService.kt
@@ -1,15 +1,14 @@
 package taeyun.malanalter.alertitem
 
-import feign.Feign
 import org.springframework.stereotype.Service
 import taeyun.malanalter.alertitem.dto.DiscordMessage
-import taeyun.malanalter.feignclient.DiscordClient
+import taeyun.malanalter.auth.discord.DiscordService
+import taeyun.malanalter.user.UserService
 
 @Service
-class AlertService(val feignBuilder: Feign.Builder) {
-    fun sendTestDiscordMessage(webhookUrl: String) {
-        val client = feignBuilder.target(DiscordClient::class.java, webhookUrl)
-        client.sendDiscordMessage(DiscordMessage.testDiscordMessage())
-
+class AlertService(val discordService: DiscordService) {
+    fun sendTestDiscordMessage() {
+        val loginUserId = UserService.getLoginUserId()
+        discordService.sendDirectMessage(loginUserId, DiscordMessage.testDiscordMessage())
     }
 }

--- a/src/main/kotlin/taeyun/malanalter/alertitem/MalanAlerterController.kt
+++ b/src/main/kotlin/taeyun/malanalter/alertitem/MalanAlerterController.kt
@@ -40,8 +40,8 @@ class MalanAlerterController(
     }
 
     @GetMapping("/discord-test")
-    fun discordTest(@RequestParam webhookUrl:String) {
-        alertService.sendTestDiscordMessage(webhookUrl)
+    fun discordTest() {
+        alertService.sendTestDiscordMessage()
     }
 
     @PatchMapping("/toggle-all")

--- a/src/main/kotlin/taeyun/malanalter/alertitem/dto/DiscordMessage.kt
+++ b/src/main/kotlin/taeyun/malanalter/alertitem/dto/DiscordMessage.kt
@@ -1,30 +1,47 @@
 package taeyun.malanalter.alertitem.dto
 
-data class DiscordMessage (
-    val content: String? = null
-){
-    constructor(bids: List<ItemBidInfo>) : this(
-        content = if (bids.isNotEmpty()) {
-            val itemName = bids[0].itemName
-            val sb = StringBuilder()
-            sb.append("```")
-            sb.append("아이템 이름: $itemName\n")
-            bids.forEach {
-                sb.append(it.toDiscordMessage())
-                sb.append("\n")
-            }
-            sb.append("```")
-            sb.toString()
-        } else null
-    )
+data class DiscordMessage(
+    val catchBids: MutableMap<Int, List<ItemBidInfo>> = mutableMapOf()
+) {
 
+    fun addBids(alertId: Int, bidsList: List<ItemBidInfo>) {
+        if (bidsList.isEmpty()) return
+        catchBids[alertId] = bidsList
+    }
+
+
+    fun getDiscordMessageContents(): List<String> = buildList {
+        // iterate catchedBids map
+        catchBids.entries.chunked(3)
+            // 청크 순회
+            .forEach { chunk ->
+                // 각 청크별로 MessageContent 생성
+                add(buildString {
+                    chunk.forEach { (_, bids) ->
+                        append("### ${getItemName(bids)} 지지알림\n")
+                        append("```\n")
+                        bids.take(5).forEach { bid ->
+                            append(bid.toDiscordMessage())
+                            append("\n")
+                        }
+                        append("```\n")
+                    }
+                })
+            }
+    }
     companion object{
-        fun testDiscordMessage():DiscordMessage{
-            return DiscordMessage("테스트 메세지 입니다.")
+        fun testDiscordMessage(): String{
+            return "톡톡🎤 매랜지지 알리미가 보내는 테스트 메세지 입니다"
+        }
+
+        fun welcomeMessage(): String{
+            // todo: 웰컴메세지에 추가 작성
+            return "메랜지지 알리미에 오신 걸 환영합니다. ... 링크"
         }
     }
 
-    override fun toString(): String {
-        return super.toString()
-    }
+
+
 }
+
+private fun getItemName(bidsList: List<ItemBidInfo>): String = bidsList.first().itemName

--- a/src/main/kotlin/taeyun/malanalter/auth/discord/DiscordService.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/discord/DiscordService.kt
@@ -27,7 +27,9 @@ class DiscordService(
     fun sendDirectMessage(userId: Long, message: String) {
         discord.retrieveUserById(userId.toString()).queue { user ->
             user.openPrivateChannel().queue { channel ->
-                channel.sendMessage(message).queue()
+                if(message.isNotBlank()){
+                    channel.sendMessage(message).queue()
+                }
             }
         }
     }

--- a/src/main/kotlin/taeyun/malanalter/user/domain/UserEntity.kt
+++ b/src/main/kotlin/taeyun/malanalter/user/domain/UserEntity.kt
@@ -20,9 +20,9 @@ class UserEntity(id: EntityID<Long>) : Entity<Long>(id) {
     var disabled by Users.disabled
     var avatar by Users.avatar
 
-    fun isAlarmTime(): Boolean {
+    fun isNotAlarmTime(): Boolean {
         val now = LocalTime.now(ZoneId.of("Asia/Seoul"))
-        return this.startTime.toJavaLocalTime().isBefore(now) &&
-                now.isBefore(this.endTime.toJavaLocalTime())
+        return now.isBefore(startTime.toJavaLocalTime()) || now.isAfter(endTime.toJavaLocalTime())
+
     }
 }


### PR DESCRIPTION
- Discord 메세지 데이터 클래스 추가
- 사용자별, 아이템별로 하나의 메세지 -> 사용자별 아이템을 3개씩 청크해서 5개의 댓글까지만 보여주도록 변경

#19 