### PR TITLE
<FIX, TEST> : 알람 시간이 range -> input 변경에 따라 새벽 시간 endTime 시 버그 픽스

### DIFF
--- a/src/main/kotlin/taeyun/malanalter/user/domain/UserEntity.kt
+++ b/src/main/kotlin/taeyun/malanalter/user/domain/UserEntity.kt
@@ -26,7 +26,20 @@ class UserEntity(id: EntityID<Long>) : Entity<Long>(id) {
             return true
         }
         val now = LocalTime.now(ZoneId.of("Asia/Seoul"))
-        return now.isBefore(startTime.toJavaLocalTime()) || now.isAfter(endTime.toJavaLocalTime())
+        val start = startTime.toJavaLocalTime()
+        val end = endTime.toJavaLocalTime()
+
+        // 유저 알람 시간이 다음날 새벽까지로 설정하는 경우가 있다
+        // 퇴근 하는 사람의 경우 19시부터 다음날 2시까지 알람을 울리게 설정할 수 있다.
+        // 이 경우는 startTime(19) endTime(2)보다 늦은 시간으로 설정된다.
+        // 체크를 반전시켜야한다.
+        return if (start.isAfter(end)) {
+            // Range spans midnight (e.g., 18:00 - 02:00)
+            now.isBefore(start) && now.isAfter(end)
+        } else {
+            // Normal range (e.g., 09:00 - 17:00)
+            now.isBefore(start) || now.isAfter(end)
+        }
 
     }
 }

--- a/src/test/kotlin/taeyun/malanalter/user/domain/UserEntityTest.kt
+++ b/src/test/kotlin/taeyun/malanalter/user/domain/UserEntityTest.kt
@@ -1,0 +1,47 @@
+package taeyun.malanalter.user.domain
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toJavaLocalTime
+
+class UserEntityTest : FunSpec({
+
+
+    fun notAlarmTime(startTime: LocalTime, endTime: LocalTime, now: java.time.LocalTime): Boolean {
+        val start = startTime.toJavaLocalTime()
+        val end = endTime.toJavaLocalTime()
+
+        return if (start.isAfter(end)) {
+            // Range spans midnight (e.g., 18:00 - 02:00)
+            now.isBefore(start) && now.isAfter(end)
+        } else {
+            // Normal range (e.g., 09:00 - 17:00)
+            now.isBefore(start) || now.isAfter(end)
+        }
+    }
+    test("19~3 일 때 현재 시간이 1시이면 알람이 울려야한다.") {
+        val startTime = LocalTime(19, 0)
+        val endTime = LocalTime(3, 0)
+        val now = java.time.LocalTime.of(1, 0)
+        notAlarmTime(startTime, endTime, now) shouldBe false
+    }
+
+    test("3 ~ 19 일 때 현재 시간이 1시이면 알람이 안 울려야한다.") {
+        val startTime = LocalTime(3, 0)
+        val endTime = LocalTime(19, 0)
+        val now = java.time.LocalTime.of(1, 0)
+        notAlarmTime(startTime, endTime, now) shouldBe true
+    }
+
+    test("3 ~ 19 일 때 현재 시간이 10시이면 알람이 울려야한다.") {
+        val startTime = LocalTime(3, 0)
+        val endTime = LocalTime(19, 0)
+        val now = java.time.LocalTime.of(10, 0)
+        notAlarmTime(startTime, endTime, now) shouldBe false
+    }
+
+
+})
+
+


### PR DESCRIPTION
- endTime 새벽일 경우 (사실상 다음날) (19 - 2) 일때 기존 로직에서 새벽 1시는 19시 이전이기 때문에 울리지 않는다.