### PR TITLE
<FIX> : 로그인, 재발급 시에 리프레시토큰을 Http only cookie 에 전달.

### DIFF
--- a/.github/workflows/alerter-be-cicd.yml
+++ b/.github/workflows/alerter-be-cicd.yml
@@ -5,7 +5,7 @@ on:
       - main
 env:
   MAJOR_VERSION: 1
-  MINOR_VERSION: 2
+  MINOR_VERSION: 3
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/main/kotlin/taeyun/malanalter/auth/AlerterCookieUtil.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/AlerterCookieUtil.kt
@@ -1,0 +1,15 @@
+package taeyun.malanalter.auth
+
+import jakarta.servlet.http.Cookie
+
+class AlerterCookieUtil {
+    companion object {
+        const val REFRESH_TOKEN_NAME = "refreshToken"
+        fun makeRefreshTokenCookie(refreshToken: String): Cookie = Cookie(REFRESH_TOKEN_NAME, refreshToken)
+            .apply {
+                isHttpOnly = true
+                maxAge = 60 * 60 * 24 * 7 // 7 days
+                path = "/"
+            }
+    }
+}

--- a/src/main/kotlin/taeyun/malanalter/auth/AuthController.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/AuthController.kt
@@ -3,38 +3,27 @@ package taeyun.malanalter.auth
 import AuthResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import taeyun.malanalter.auth.dto.LoginRequest
 import taeyun.malanalter.auth.dto.RefreshRequest
 import taeyun.malanalter.config.exception.AlerterBadRequest
 import taeyun.malanalter.config.exception.ErrorCode
 import taeyun.malanalter.user.UserService
-import taeyun.malanalter.user.dto.UserRegisterRequest
+import java.time.LocalTime
+import java.time.ZoneId
 
-private val logger = KotlinLogging.logger{}
+private val logger = KotlinLogging.logger {}
+
 @RestController
 @RequestMapping("/alerter/auth")
 class AuthController(
     val userService: UserService,
-    val authService: AuthService
+    val authService: AuthService,
 ) {
-
-    @PostMapping("/register")
-    @Deprecated(message = "deprecated", replaceWith = ReplaceWith("/oauth2/authorization/discord"))
-    fun register(@RequestBody  @Valid userRegisterRequest: UserRegisterRequest) {
-        throw AlerterBadRequest(ErrorCode.DEPRECATED_API,null)
-    }
-
-    @PostMapping("/login")
-    @Deprecated(message = "deprecated", replaceWith = ReplaceWith("/oauth2/authorization/discord"))
-    fun login(@RequestBody @Valid loginRequest: LoginRequest) : ResponseEntity<AuthResponse>{
-        throw AlerterBadRequest(ErrorCode.DEPRECATED_API,null)
-    }
 
     @PostMapping("/logout")
     fun logout(request: HttpServletRequest) {
@@ -42,13 +31,21 @@ class AuthController(
         authService.logout(tokenFromRequest) // accessToken 을 블랙리스트에 추가
     }
 
+    // 모든 저장된 리프레시 토큰이 만료되는 pr 시점 7일 이후에 refreshRequest 삭제
     @PostMapping("/refresh")
-    fun refresh(@RequestBody @Valid refreshRequest: RefreshRequest): ResponseEntity<AuthResponse>? {
-        // find user
-        val foundUser = userService.findById(refreshRequest.getUsername())
-        // check
-        val renewTokenResponse = authService.renewToken(foundUser, refreshRequest.refreshToken.orEmpty())
-        return ResponseEntity.ok(renewTokenResponse)
+    fun refresh(
+        @RequestBody @Valid refreshRequest: RefreshRequest,
+        request: HttpServletRequest,
+        response: HttpServletResponse
+    ): AuthResponse {
+        // first check refresh cookie
+        val refreshTokenFromCookie = request.cookies?.find { it.name == AlerterCookieUtil.REFRESH_TOKEN_NAME }?.value
+        if (refreshTokenFromCookie.isNullOrEmpty()) {
+            logger.warn { "이전 버전의 refresh 요청 : ${LocalTime.now(ZoneId.of("Asia/Seoul"))} 유저 ${refreshRequest.userId}" }
+        }
+        val refreshToken = refreshTokenFromCookie ?: refreshRequest.refreshToken
+        ?: throw AlerterBadRequest(ErrorCode.REFRESH_TOKEN_NOT_FOUND, "Refresh token not found in request body")
+        val findById = userService.findById(refreshRequest.userId!!)
+        return authService.renewToken(findById, refreshToken, response)
     }
-
 }

--- a/src/main/kotlin/taeyun/malanalter/auth/dto/AuthResponse.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/dto/AuthResponse.kt
@@ -1,7 +1,6 @@
 
 data class AuthResponse(
     val accessToken: String,
-    val refreshToken: String,
     val type: String = "Bearer",
     val expireAt: Long
 )

--- a/src/main/kotlin/taeyun/malanalter/auth/dto/RefreshRequest.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/dto/RefreshRequest.kt
@@ -1,14 +1,9 @@
 package taeyun.malanalter.auth.dto
 
-import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class RefreshRequest (
-    @field:NotBlank
-    private val username: String?,
-    @field:NotBlank
+    @field:NotNull(message = "UserId 는 Null일 수 없습니다.")
+    val userId: Long?,
     val refreshToken: String?
-){
-    fun getUsername():Long{
-        return username!!.toLong()
-    }
-}
+)

--- a/src/main/kotlin/taeyun/malanalter/config/exception/ErrorCode.kt
+++ b/src/main/kotlin/taeyun/malanalter/config/exception/ErrorCode.kt
@@ -7,23 +7,18 @@ enum class ErrorCode(
     val code: String,
     val defaultMessage: String // if exception's message not defined
 ) {
-    // AUTH_002, AUTH_003 은 무조건 전부 /login 으로 이동한다.
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid Token"),
+    // AUTH_002, AUTH_003 은 무조건 전부 /login 으로 이동한다.
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "Expired AccessToken : refresh required"),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "Expired Refresh Token RE-login required"),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_004", "Refresh Token not found"),
-
-    // Login
-    WRONG_PASSWORD(HttpStatus.NOT_ACCEPTABLE, "AUTH_005", "WRONG_PASSWORD"),
-    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_005", "Logout Account"),
-
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_002", "Refresh Token not found"),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "Expired Refresh Token RE-login required"),
+    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "Logout Account"),
     DISCORD_TOKEN_NOTFOUND(HttpStatus.BAD_REQUEST, "AUTH_006", "No discord access token found"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "User Not Found"),
-    USER_EXIST(HttpStatus.BAD_REQUEST, "USER_002", "User Already Exist"),
 
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_001", "Internal Server Error"),
-    DEPRECATED_API(HttpStatus.BAD_REQUEST, "SERVER_002", "Request to deprecated API"),
 }

--- a/src/main/kotlin/taeyun/malanalter/config/exception/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/taeyun/malanalter/config/exception/GlobalControllerAdvice.kt
@@ -4,10 +4,12 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 val logger = KotlinLogging.logger{}
+
 @RestControllerAdvice
 class GlobalControllerAdvice {
 
@@ -15,17 +17,24 @@ class GlobalControllerAdvice {
     fun handleBaseException(ex: BaseException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         // 서버에러의 경우 추적할 수 있는 uuid 와 함께 root cause 와 함께
         if (ex is AlerterServerError) {
-            logger.error { "[${ex.uuid}] Server Error occur : ${ex.rootCause?.message?:ex.message}" }
+            logger.error { "[${ex.uuid}] Server Error occur : ${ex.rootCause?.message ?: ex.message}" }
         }
         val errorResponse = ErrorResponse.of(ex)
         return ResponseEntity.status(errorResponse.status).body(errorResponse)
     }
 
     @ExceptionHandler(RuntimeException::class)
-    fun handleServerError(ex: RuntimeException):ResponseEntity<ErrorResponse>{
+    fun handleServerError(ex: RuntimeException): ResponseEntity<ErrorResponse> {
         logger.error { "Internal Server Error with ${ex.message}" }
         val errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR)
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse)
+    }
+
+    @ExceptionHandler(BindException::class)
+    fun handleBindError(e: BindException): ResponseEntity<ErrorResponse>{
+        val errormsg = e.bindingResult.allErrors[0].defaultMessage
+        val errorResponse = ErrorResponse.of(AlerterBadRequest(ErrorCode.BAD_REQUEST, message = errormsg))
+        return ResponseEntity.status(errorResponse.status).body(errorResponse)
     }
 
 }

--- a/src/test/kotlin/taeyun/malanalter/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/taeyun/malanalter/auth/AuthControllerTest.kt
@@ -1,0 +1,50 @@
+package taeyun.malanalter.auth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.mockk
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import taeyun.malanalter.auth.dto.RefreshRequest
+import taeyun.malanalter.config.exception.ErrorCode
+import taeyun.malanalter.config.exception.GlobalControllerAdvice
+import taeyun.malanalter.user.UserService
+import taeyun.malanalter.user.domain.UserEntity
+
+class AuthControllerTest : FunSpec({
+
+
+    val userService = mockk<UserService>()
+    val authService = mockk<AuthService>()
+    val mapper = ObjectMapper()
+    val username = 100L
+
+
+    val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(AuthController(userService, authService))
+        .setControllerAdvice(GlobalControllerAdvice())
+        .build()
+
+
+    val mockUser = mockk<UserEntity>()
+
+
+    test("http only cookie, request body 모두 없으면 재로그인 에러 응답") {
+        val emptyRefreshTokenRequest = RefreshRequest(username, null)
+
+        mockMvc.perform(
+            post("/alerter/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(emptyRefreshTokenRequest))
+        )
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.code").value(ErrorCode.REFRESH_TOKEN_NOT_FOUND.code))
+    }
+
+
+
+
+})


### PR DESCRIPTION
- Deprecated Controller 삭제 -> 사용자 등록, 로그인
- OAuth2SuccessHandler 에서 refresh Token 은 Cookie에 넣어 전달.
- AuthController 의 재발급에서 하위 호환을 위해 refreshToken 유지, 토큰을 우선한 재발급 진행
- 재발급 응답에서 refreshToken 제거
- GlobalControllerAdvice 에서 Validation Exception 공통화