### PR TITLE
<Fix> : 전반적인 Exception 로깅 방식 수정

### DIFF
--- a/src/main/kotlin/taeyun/malanalter/auth/AuthService.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/AuthService.kt
@@ -73,7 +73,7 @@ class AuthService(
                     accessToken = generateAccessToken,
                     expireAt = jwtUtil.getExpiryFromToken(generateAccessToken).toInstant().epochSecond
                 )
-            } ?: throw AlerterNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND)
+            } ?: throw AlerterNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND, "액세스 토큰 재발급에서 Token을 찾을 수 없음 유저 : ${foundUser.username} 리프레시 토큰: [$refreshToken] ")
         }
     }
 

--- a/src/main/kotlin/taeyun/malanalter/auth/JwtUtil.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/JwtUtil.kt
@@ -22,7 +22,7 @@ class JwtUtil(val authProperties: AuthProperties) {
     companion object {
         fun getTokenFromRequest(request: HttpServletRequest) : String {
             val authHeader = request.getHeader("Authorization")
-            if (authHeader == null || !authHeader.startsWith("Bearer")) {
+            if (authHeader.isNullOrEmpty() || !authHeader.startsWith("Bearer")) {
                 logger.info{"No Auth Requested From Host :  ${request.requestURL}"}
                 throw AlerterJwtException(ErrorCode.INVALID_TOKEN, "No Auth header in request")
             }
@@ -67,13 +67,15 @@ class JwtUtil(val authProperties: AuthProperties) {
             extractClaim(token, Claims::getExpiration).before(Date())
         } catch (e: ExpiredJwtException) {
             true
+        }catch (e:JwtException){
+            logger.error { "만료일 추출중 에러발생 토큰: $token" }
+            throw e
         }
     }
 
     // username 은 만료됬어도 반환한다.
     fun getUserFromExpiredToken(token: String):Long{
         return try {
-
             Jwts.parser()
                 .verifyWith(key)
                 .build()

--- a/src/main/kotlin/taeyun/malanalter/config/exception/ErrorCode.kt
+++ b/src/main/kotlin/taeyun/malanalter/config/exception/ErrorCode.kt
@@ -8,13 +8,14 @@ enum class ErrorCode(
     val defaultMessage: String // if exception's message not defined
 ) {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "Invalid Token"),
-    // AUTH_002 는 리프레시 요청을
+    // AUTH_002 는 리프레시 요청
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "Expired AccessToken : refresh required"),
-    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "Logout Account"),
 
-    // AUTH_003 은 로그인으로 보낸다.
+    // AUTH_003 은 로그인으로 푸시한다(FE).
+    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "Logout Account"),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_003", "Refresh Token not found"),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "Expired Refresh Token RE-login required"),
+
     DISCORD_TOKEN_NOTFOUND(HttpStatus.BAD_REQUEST, "AUTH_006", "No discord access token found"),
 
     // User

--- a/src/main/kotlin/taeyun/malanalter/config/exception/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/taeyun/malanalter/config/exception/GlobalControllerAdvice.kt
@@ -17,15 +17,16 @@ class GlobalControllerAdvice {
     fun handleBaseException(ex: BaseException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         // 서버에러의 경우 추적할 수 있는 uuid 와 함께 root cause 와 함께
         if (ex is AlerterServerError) {
-            logger.error { "[${ex.uuid}] Server Error occur : ${ex.rootCause?.message ?: ex.message}" }
+            logger.error { "[${ex.uuid}] Server Error occur : ${ex.rootCause?.message ?: ex.message}\n 스택 트레이스 ${ex.rootCause?.printStackTrace()}" }
         }
+        logger.warn { "[${ex.errorCode.status}]  ${ex.message}" }
         val errorResponse = ErrorResponse.of(ex)
         return ResponseEntity.status(errorResponse.status).body(errorResponse)
     }
 
     @ExceptionHandler(RuntimeException::class)
     fun handleServerError(ex: RuntimeException): ResponseEntity<ErrorResponse> {
-        logger.error { "Internal Server Error with ${ex.message}" }
+        logger.error { "Internal Server Error with ${ex.message} \n\n ${ex.printStackTrace()}" }
         val errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR)
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse)
     }


### PR DESCRIPTION
- AuthService의 send message 로깅추가
- JwtExceptionFilter 는 AlertJwtException 만 처리하는 것으로 변경 -> 나머지가 처리되면 GlobalControllerAdvice가 의미 없음
- Error 코드 변경 logout Token 은 로그인으로
- JwtAuthenticationFilter의 로거 변경 및 stacktrace 출력