### PR TITLE
feat. jda의 메세지 발송 실패 코드 변경 대응

### DIFF
--- a/src/main/kotlin/taeyun/malanalter/auth/discord/DiscordService.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/discord/DiscordService.kt
@@ -29,6 +29,15 @@ class DiscordService(
     companion object {
         val URL_PATTERN = Regex("\\[링크]\\(https://mapleland\\.gg/trade/([^)]+)\\)")
         const val MAX_FAILURE_COUNT = 3
+
+        // 에러 문자열을 검사하여 사용자가 서버를 탈퇴했거나 DM 수신이 불가능한 상태인지 판별
+        // 50007: Cannot send messages to this user (DM 차단/비공개)
+        // 50278: 서버를 떠난 사용자 관련 에러
+        // CANNOT_SEND_TO_USER: JDA가 노출하는 에러 상수명
+        fun isLeftUser(errorString: String): Boolean =
+            errorString.contains("50007") ||
+                    errorString.contains("50278") ||
+                    errorString.contains("CANNOT_SEND_TO_USER")
     }
 
     fun addUserToServer(discordUser: DiscordOAuth2User) {
@@ -71,7 +80,7 @@ class DiscordService(
                                     logger.error {
                                         "Failed to send message to user $userId: ${error.message}\n message : ${message.substring(0,15)}..."
                                     }
-                                    if (error.toString().contains("50007") || error.toString().contains("CANNOT_SEND_TO_USER")) {
+                                    if (isLeftUser(error.toString())) {
                                         handleCannotSendToUserError(userId)
                                     }
                                 }

--- a/src/test/kotlin/taeyun/malanalter/auth/discord/DiscordServiceTest.kt
+++ b/src/test/kotlin/taeyun/malanalter/auth/discord/DiscordServiceTest.kt
@@ -12,5 +12,30 @@ class DiscordServiceTest : StringSpec({
         matchResult!!.groupValues[1] shouldBe "test-url"
     }
 
+    // isLeftUser 함수는 Discord 에러 문자열을 보고 "사용자가 서버를 탈퇴했거나 DM 수신 불가 상태인지" 판별한다
+    "isLeftUser - 50278 코드가 포함된 에러는 true" {
+        // Discord 에러 코드 50278이 에러 메시지에 포함된 케이스
+        DiscordService.isLeftUser("ErrorResponseException: 50278: Something failed") shouldBe true
+    }
+
+    "isLeftUser - CANNOT_SEND_TO_USER 문자열이 포함된 에러는 true" {
+        // Discord가 반환하는 CANNOT_SEND_TO_USER 에러 상수 케이스
+        DiscordService.isLeftUser("net.dv8tion.jda.api.exceptions.ErrorResponseException: CANNOT_SEND_TO_USER") shouldBe true
+    }
+
+    "isLeftUser - 관련 없는 에러는 false" {
+        // 전혀 다른 에러 메시지는 사용자 탈퇴와 무관하므로 false
+        DiscordService.isLeftUser("java.net.SocketTimeoutException: Read timed out") shouldBe false
+    }
+
+    "isLeftUser - 빈 문자열은 false" {
+        // 경계값: 빈 문자열은 매칭되지 않아야 함
+        DiscordService.isLeftUser("") shouldBe false
+    }
+
+    "isLeftUser - 50007 코드(Cannot send messages to this user)가 포함된 에러는 true" {
+        // Discord 공식 에러 코드 50007: DM이 비활성화되었거나 봇을 차단한 사용자
+        DiscordService.isLeftUser("ErrorResponseException: 50007: Cannot send messages to this user") shouldBe true
+    }
 
 })


### PR DESCRIPTION
### why
- jda 업데이트 이후 서버를 떠난 유저의 에러 코드가 달라져 알람 체크 밴이 되지 않는 이슈 해결